### PR TITLE
Add jest test for translation handler

### DIFF
--- a/__tests__/translate.test.js
+++ b/__tests__/translate.test.js
@@ -1,0 +1,21 @@
+import handler from '../api/translate.js';
+import { jest } from '@jest/globals';
+
+describe('translate handler', () => {
+  it('returns translation string', async () => {
+    const req = { body: { text: 'こんにちは' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({
+        choices: [ { message: { content: '你好' } } ]
+      })
+    });
+
+    await handler(req, res);
+
+    expect(fetch).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ translation: '你好' });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "translate-private-vercel",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up package.json with `jest` test script
- add unit test for translation API handler

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824cb4caec832e9fe5014b57abee8b